### PR TITLE
Fix login endpoint in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Gestión de usuarios (registro, verificación, login, tipo de usuario).
   - `POST /usuarios`: Crear usuario
   - `GET /usuarios/{id}`: Obtener información de usuario
   - `PUT /usuarios/{id}`: Editar usuario
-  - `POST /usuarios/login`: Iniciar sesión
+  - `POST /auth/login`: Iniciar sesión
 
 - **Tecnologías:**
   - Spring Boot


### PR DESCRIPTION
## Summary
- fix login endpoint path in `README`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7ff2e0648322870845d58aa88f13