### PR TITLE
Add JwtUtil unit tests

### DIFF
--- a/users-service/src/test/java/com/marketplace/users/security/JwtUtilTest.java
+++ b/users-service/src/test/java/com/marketplace/users/security/JwtUtilTest.java
@@ -1,0 +1,25 @@
+package com.marketplace.users.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtUtilTest {
+
+    @Test
+    void generatedTokenIsValid() {
+        JwtUtil jwtUtil = new JwtUtil();
+        String token = jwtUtil.generateToken("testuser", List.of("ROLE_USER"));
+        assertTrue(jwtUtil.validateToken(token));
+    }
+
+    @Test
+    void getUsernameFromTokenReturnsExpectedUser() {
+        JwtUtil jwtUtil = new JwtUtil();
+        String username = "anotherUser";
+        String token = jwtUtil.generateToken(username);
+        assertEquals(username, jwtUtil.getUsernameFromToken(token));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for generating tokens and extracting username

## Testing
- `mvn -q -pl users-service test` *(fails: command not found)*
- `./mvnw -q test` in users-service *(fails: can't fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_684c806c2a608322a0523b16c7a6c0dd