### PR TITLE
Add unit tests for JwtUtil

### DIFF
--- a/users-service/src/test/java/com/marketplace/users/security/JwtUtilTest.java
+++ b/users-service/src/test/java/com/marketplace/users/security/JwtUtilTest.java
@@ -2,21 +2,19 @@ package com.marketplace.users.security;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 class JwtUtilTest {
 
     @Test
-    void generatedTokenIsValid() {
+    void generateAndValidateToken() {
         JwtUtil jwtUtil = new JwtUtil();
-        String token = jwtUtil.generateToken("testuser", List.of("ROLE_USER"));
-        assertTrue(jwtUtil.validateToken(token));
+        String token = jwtUtil.generateToken("testuser");
+        assertTrue(jwtUtil.validateToken(token), "Token should be valid");
     }
 
     @Test
-    void getUsernameFromTokenReturnsExpectedUser() {
+    void extractUsernameFromToken() {
         JwtUtil jwtUtil = new JwtUtil();
         String username = "anotherUser";
         String token = jwtUtil.generateToken(username);


### PR DESCRIPTION
## Summary
- implement JwtUtil tests verifying token validation and username extraction

## Testing
- `mvn -q -pl users-service test` *(fails: mvn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c81b6da6083229c378c370853c6a4